### PR TITLE
save app state

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -30,6 +30,13 @@ int main(int argc, char ** argv) {
 
     // Create window.
     QApplication app(argc, argv);
+
+    // NOTE: set app variables which will be used to
+    // construct settings path
+    app.setOrganizationName("BaseALT");
+    app.setOrganizationDomain("basealt.ru");
+    app.setApplicationName("GPUI");
+    
     gpui::MainWindow window;
     window.show();
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -27,6 +27,10 @@
 
 namespace gpui {
 
+const QString MAIN_WINDOW_GEOMETRY = "mainwindow/geometry";
+const QString MAIN_WINDOW_STATE = "mainwindow/state";
+const QString MAIN_WINDOW_SPLITTER_STATE = "mainwindow/splitterState";
+
 class MainWindowPrivate {
 public:
     std::unique_ptr<QStandardItemModel> model;
@@ -44,6 +48,18 @@ MainWindow::MainWindow(QWidget *parent)
 
     ui->splitter->addWidget(d->contentWidget);
 
+    // Restore settings
+    const QSettings settings;
+
+    const QByteArray geometry = settings.value(MAIN_WINDOW_GEOMETRY).toByteArray();
+    restoreGeometry(geometry);
+
+    const QByteArray state = settings.value(MAIN_WINDOW_STATE).toByteArray();
+    restoreState(state);
+
+    const QByteArray splitterState = settings.value(MAIN_WINDOW_SPLITTER_STATE).toByteArray();
+    ui->splitter->restoreState(splitterState);
+
     connect(ui->actionOpen_Policy_Directory, &QAction::triggered, this, &MainWindow::onDirectoryOpen);
     connect(ui->treeView, &QTreeView::clicked, d->contentWidget, &ContentWidget::modelItemSelected);
 }
@@ -53,6 +69,23 @@ MainWindow::~MainWindow()
     delete d;
 
     delete ui;
+}
+
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    // Save settings
+    QSettings settings;
+
+    const QByteArray geometry = saveGeometry();
+    settings.setValue(MAIN_WINDOW_GEOMETRY, geometry);
+
+    const QByteArray state = saveState();
+    settings.setValue(MAIN_WINDOW_STATE, state);
+
+    const QByteArray splitterState = ui->splitter->saveState();
+    settings.setValue(MAIN_WINDOW_SPLITTER_STATE, splitterState);
+
+    QMainWindow::closeEvent(event);
 }
 
 void MainWindow::onDirectoryOpen()

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -41,6 +41,9 @@ namespace gpui {
         MainWindow(QWidget *parent = 0);
         ~MainWindow();
 
+    protected:
+        void closeEvent(QCloseEvent *event) override;
+
     private:
 
         MainWindowPrivate* const d;


### PR DESCRIPTION
Implement saving app state to settings.

Not that much app state at the moment, so saved just what I could find:
- main window geometry
- main window state
- splitter state

