### PR TITLE
fix: fix spinbox, remove infint add signal for message box in spinbox

### DIFF
--- a/src/gui/altspinbox.cpp
+++ b/src/gui/altspinbox.cpp
@@ -1,8 +1,5 @@
 #include "altspinbox.h"
-
 #include <QDebug>
-
-#include "infint.h"
 
 namespace gui
 {
@@ -12,17 +9,22 @@ void AltSpinBox::fixup(QString &input) const
     qWarning() << "AltSpinBox::fixup " << input << " " << minimum() << " " << maximum();
 
     QRegExp regExp("(-?)(\\+?)\\d+");
-    auto isOk = regExp.exactMatch(input);
-    auto value = InfInt(input.toStdString());
+    if (!regExp.exactMatch(input))
+    {
+        QSpinBox::fixup(input);
+        return;
+    }
+    bool isOk = false;
+    int value = input.toInt(&isOk);
     if (isOk)
     {
-        value = qBound(InfInt(minimum()), value, InfInt(maximum()));
-        input = QString::number(value.toInt(), displayIntegerBase());
+        value = qBound(minimum(), value, maximum());
+        input = QString::number(value, displayIntegerBase());
         qWarning() << "AltSpinBox::fixup " << input;
     }
     else
     {
-        QSpinBox::fixup(input);
+        emit fixToValidRange(input);
     }
 }
 

--- a/src/gui/altspinbox.h
+++ b/src/gui/altspinbox.h
@@ -33,8 +33,10 @@ class AltSpinBox final : public QSpinBox
     Q_OBJECT
 protected:
     void fixup(QString &input) const override;
-
     QValidator::State validate(QString &text, int &pos) const override;
+
+signals:
+    void fixToValidRange(const QString &wrongInput) const;
 };
 
 }


### PR DESCRIPTION
- removed Infint usage, now strings with too long values is handled as no regexp-matching and not to int converted
- added fixToValidRange signal in AltSpinBox class: signal is connected with lambda in presentationbuilder.cpp, where string with too long value is fixed and messagebox is showed