### PR TITLE
fix: fix comment file name

### DIFF
--- a/src/plugins/administrative_templates/comments/commentsmodel.cpp
+++ b/src/plugins/administrative_templates/comments/commentsmodel.cpp
@@ -298,6 +298,8 @@ void CommentsModel::save(const QString &path, const QString& localeName)
 
     commentDefinitions->resources = std::make_unique<LocalizationResourceReference>();
 
+    bool enableLocalizedComments = localeName != "en-US";
+
     for (const auto& comment : comments)
     {
         namespaceIndex = 0;
@@ -320,10 +322,13 @@ void CommentsModel::save(const QString &path, const QString& localeName)
 
         commentDefinitions->comments.push_back(currentComment);
 
-        commentDefinitions->resources->stringTable.emplace_back(comment.second.toStdString(), resourceName);
+        commentDefinitions->resources->stringTable.emplace_back((enableLocalizedComments
+                                                                ? ""
+                                                                : comment.second.toStdString()),
+                                                                resourceName);
     }
 
-    if (localeName != "en-US")
+    if (enableLocalizedComments)
     {
         auto cmtlFileName = path + "comment.cmtl";
 

--- a/src/plugins/administrative_templates/comments/commentsmodel.cpp
+++ b/src/plugins/administrative_templates/comments/commentsmodel.cpp
@@ -325,7 +325,7 @@ void CommentsModel::save(const QString &path, const QString& localeName)
 
     if (localeName != "en-US")
     {
-        auto cmtlFileName = path + "comments.cmtl";
+        auto cmtlFileName = path + "comment.cmtl";
 
         std::shared_ptr<comments::CommentDefinitionResources> commentResources
                 = std::make_shared<comments::CommentDefinitionResources>();
@@ -353,7 +353,7 @@ void CommentsModel::save(const QString &path, const QString& localeName)
                                                                                      commentResources);
     }
 
-    auto cmtxFileName = path + "comments.cmtx";
+    auto cmtxFileName = path + "comment.cmtx";
 
     savePolicies<io::PolicyCommentsFile, comments::PolicyComments>("cmtx", cmtxFileName, commentDefinitions);
 }

--- a/src/plugins/administrative_templates/comments/localizationresourcereference.h
+++ b/src/plugins/administrative_templates/comments/localizationresourcereference.h
@@ -44,7 +44,7 @@ public:
      *  Both have equal major components, and the minor component of the revision attribute is greater than or equal
      *  to the minor component of the minRequiredVersion attribute.
      */
-    double minRequiredRevision{};
+    std::string minRequiredRevision{"1.0"};
 
     /*!
      * \brief fallbackCulture  Language to fallback to.

--- a/src/plugins/administrative_templates/comments/policycomments.h
+++ b/src/plugins/administrative_templates/comments/policycomments.h
@@ -46,12 +46,12 @@ public:
     /*!
      * \brief revision The revision number.
      */
-    double revision{0};
+    std::string revision{"1.0"};
 
     /*!
      * \brief schemaVersion The version number of the applicable schema.
      */
-    double schemaVersion{0};
+    std::string schemaVersion{"1.0"};
     /*!
      * \brief comments  List of comments.
      */

--- a/src/plugins/cmtx/schema/cmtx.xsd
+++ b/src/plugins/cmtx/schema/cmtx.xsd
@@ -52,12 +52,12 @@
                 </xs:complexType>
               </xs:element>
             </xs:sequence>
-            <xs:attribute name="minRequiredRevision" type="xs:decimal" use="required" />
+            <xs:attribute name="minRequiredRevision" type="xs:string" use="required" />
           </xs:complexType>
         </xs:element>
       </xs:sequence>
-      <xs:attribute name="revision" type="xs:decimal" use="required" />
-      <xs:attribute name="schemaVersion" type="xs:decimal" use="required" />
+      <xs:attribute name="revision" type="xs:string" use="required" />
+      <xs:attribute name="schemaVersion" type="xs:string" use="required" />
     </xs:complexType>
   </xs:element>
 </xsd:schema>


### PR DESCRIPTION
Following fixes were added:
- Adjust localized comments.
- Fix comment file name.
- Fix cmtx schema to support proper revision, version and minRequiredVersion.