### PR TITLE
feat: set C++ version 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(GPUI)
+set(CMAKE_CXX_STANDARD 17)
 
 execute_process(
     COMMAND


### PR DESCRIPTION
There is a need for C++ 17 due to the presence of std::optional in it.