### PR TITLE
[GPUI][BUG] Incorrectly saves/displays the comment value.

### DIFF
--- a/src/plugins/administrative_templates/comments/commentsmodel.cpp
+++ b/src/plugins/administrative_templates/comments/commentsmodel.cpp
@@ -162,7 +162,7 @@ void savePolicies(const QString &pluginName, const QString &fileName, std::share
 
 QString constructCMTLFileName(const QFileInfo &fileName)
 {
-    QString admlFileName = fileName.fileName();
+    QString admlFileName = fileName.filePath();
     admlFileName.replace(admlFileName.length() - 4, 4, "cmtl");
 
     return admlFileName;


### PR DESCRIPTION
RSAT:
![image](https://github.com/user-attachments/assets/5cbd3db9-9acd-428a-a447-5d17328f83ba)
GPUI:
![image](https://github.com/user-attachments/assets/45f99e70-a578-4158-b6e5-5ae17a5b2622)
Versions:
- gpui-0.2.32-alt1
### Conditions
Installed packages on the client:
```bash
apt-get install -y gpui admc admx-basealt
```
### Playback Steps

1. Log in to the client as a domain user.
2. Open ADMC (kinit administrator && admc) → Group Policy Objects → PCM by Default Domain Policy → To change.
3. Go to Machine → Administrative Templates → ALT System → Security → Permission for /bin/su.
4. Set some value for the Comment/Comment field, for example, test.
5. Check this value on another GPU client and in RSAT.

Expected result: the comment is displayed correctly on another client and in RSAT.

The actual result: in RSAT it is displayed as $(resource.ns0_su), on
another client with GPU the value is not displayed at all.