### PR TITLE
[GPUI][BUG] Incorrectly saves/displays the comment value. Continue of #70

### DIFF
--- a/src/plugins/administrative_templates/administrativetemplatessnapin.cpp
+++ b/src/plugins/administrative_templates/administrativetemplatessnapin.cpp
@@ -486,11 +486,14 @@ void AdministrativeTemplatesSnapIn::setMenuItemNames()
 
 void AdministrativeTemplatesSnapIn::onRetranslateUI(const std::string &locale)
 {
+    QString localeName = QString::fromStdString(locale);
     d->localeName = locale;
     d->policyBundleLoad();
     setMenuItemNames();
     d->filterDialog->onLanguageChanged();
     d->updateFilter();
+    d->machineCommentsModel->load(d->machineCommentsPath + "/comment.cmtx", localeName);
+    d->userCommentsModel->load(d->userCommentsPath + "/comment.cmtx", localeName);
     setRootNode(static_cast<QAbstractItemModel *>(d->filterModel.get()));
 }
 

--- a/src/plugins/administrative_templates/administrativetemplatessnapin.cpp
+++ b/src/plugins/administrative_templates/administrativetemplatessnapin.cpp
@@ -438,10 +438,10 @@ void AdministrativeTemplatesSnapIn::onShutdown()
 
 void AdministrativeTemplatesSnapIn::onDataLoad(const std::string &policyPath, const std::string &locale)
 {
-    Q_UNUSED(locale);
-
     if (!policyPath.empty())
     {
+        QString localeName = QString::fromStdString(locale);
+
         d->policyPath = policyPath;
 
         d->userRegistryPath    = QString::fromStdString(policyPath) + "/User/Registry.pol";
@@ -464,8 +464,8 @@ void AdministrativeTemplatesSnapIn::onDataLoad(const std::string &policyPath, co
         d->proxyModel->setMachineRegistrySource(d->machineRegistrySource.get());
         d->filterModel->setMachineRegistrySource(d->machineRegistrySource.get());
 
-        d->machineCommentsModel->load(QString::fromStdString(policyPath) + "/Machine/comment.cmtx");
-        d->userCommentsModel->load(QString::fromStdString(policyPath) + "/User/comment.cmtx");
+        d->machineCommentsModel->load(QString::fromStdString(policyPath) + "/Machine/comment.cmtx", localeName);
+        d->userCommentsModel->load(QString::fromStdString(policyPath) + "/User/comment.cmtx", localeName);
 
         d->proxyModel->setMachineCommentModel(d->machineCommentsModel.get());
         d->proxyModel->setUserCommentModel(d->userCommentsModel.get());

--- a/src/plugins/administrative_templates/comments/commentsmodel.cpp
+++ b/src/plugins/administrative_templates/comments/commentsmodel.cpp
@@ -322,36 +322,9 @@ void CommentsModel::save(const QString &path, const QString& localeName)
         currentComment.commentText = "$(resource." + resourceName + ")";
 
         commentDefinitions->comments.push_back(currentComment);
+
+        commentDefinitions->resources->stringTable.emplace_back((comment.second.toStdString()), resourceName);
     }
-
-    QDir().mkpath(path + localeName.toLower());
-    auto cmtlFileName = path + localeName.toLower() + "/" + "comment.cmtl";
-
-    std::shared_ptr<comments::CommentDefinitionResources> commentResources
-            = std::make_shared<comments::CommentDefinitionResources>();
-
-    for (const auto& comment : comments)
-    {
-        namespaceIndex = 0;
-
-        for (const auto& currentNamespace : commentDefinitions->policyNamespaces.using_)
-        {
-            if (comment.namespace_.compare(currentNamespace.namespace_.c_str()) == 0)
-            {
-                break;
-            }
-
-            namespaceIndex++;
-        }
-
-        commentResources->stringTable.emplace_back(comment.second.toStdString(),
-                                                    "ns" + std::to_string(namespaceIndex)
-                                                    + "_" + comment.first.toStdString());
-    }
-
-    savePolicies<io::CommentResourcesFile, comments::CommentDefinitionResources>("cmtl", cmtlFileName,
-                                                                                    commentResources);
-
 
     auto cmtxFileName = path + "comment.cmtx";
 

--- a/src/plugins/administrative_templates/comments/commentsmodel.cpp
+++ b/src/plugins/administrative_templates/comments/commentsmodel.cpp
@@ -162,8 +162,7 @@ void savePolicies(const QString &pluginName, const QString &fileName, std::share
 
 QString constructCMTLFileName(const QFileInfo &fileName, const QString &localeName)
 {
-    QString localFolder = localeName.toLower(); // en-US -> en-us. ru-RU -> ru-ru and etc.
-    QString admlFileName = fileName.absoluteDir().path() + "/" + localFolder + "/" + fileName.baseName() + ".cmtl";
+    QString admlFileName = fileName.absoluteDir().path() + "/" + localeName + "/" + fileName.baseName() + ".cmtl";
     return admlFileName;
 }
 

--- a/src/plugins/administrative_templates/comments/commentsmodel.h
+++ b/src/plugins/administrative_templates/comments/commentsmodel.h
@@ -41,7 +41,7 @@ public:
 public:
     CommentsModel(QObject* parent = nullptr);
 
-    void load(const QString& path);
+    void load(const QString& path, const QString &localeName);
     void save(const QString &path, const QString &localeName);
 
     QModelIndex indexFromItemReference(const QString &itemRef);


### PR DESCRIPTION
GPUI:
![image](https://github.com/user-attachments/assets/45f99e70-a578-4158-b6e5-5ae17a5b2622)
Versions:
- gpui-0.2.32-alt1
### Conditions
Installed packages on the client:
```bash
apt-get install -y gpui admc admx-basealt
```
### Playback Steps

1. Log in to the client as a domain user.
2. Open ADMC (kinit administrator && admc) → Group Policy Objects → PCM by Default Domain Policy → To change.
3. Go to Machine → Administrative Templates → ALT System → Security → Permission for /bin/su.
4. Set some value for the Comment/Comment field, for example, test.
5. Restart and check.

Expected result: the comment is displayed correctly.

The actual result: the comment is not displayed.