### PR TITLE
[GPUI][BUG]The URL list is incorrectly saved in the Yandex Browser policy for windows clients

### DIFF
--- a/src/plugins/administrative_templates/registry/abstractregistrysource.h
+++ b/src/plugins/administrative_templates/registry/abstractregistrysource.h
@@ -48,8 +48,12 @@ public:
     virtual void markValueForDeletion(const std::string &key, const std::string &valueName)           = 0;
     virtual bool undeleteValue(const std::string &key, const std::string &valueName)                  = 0;
     virtual bool isValueMarkedForDeletion(const std::string &key, const std::string &valueName) const = 0;
+    
+    virtual std::vector<std::string> getNonSpecialValueNames(const std::string &key) const = 0;
+    virtual std::vector<std::string> getValueNames(const std::string &key) const           = 0;
+    
+    virtual void markValueNamesInKeyForDeletion(const std::string &key) = 0;
 
-    virtual std::vector<std::string> getValueNames(const std::string &key) const  = 0;
     virtual void clearKey(const std::string &key)                                 = 0;
     virtual void clearValue(const std::string &key, const std::string &valueName) = 0;
 

--- a/src/plugins/administrative_templates/registry/abstractregistrysource.h
+++ b/src/plugins/administrative_templates/registry/abstractregistrysource.h
@@ -52,7 +52,7 @@ public:
     virtual std::vector<std::string> getNonSpecialValueNames(const std::string &key) const = 0;
     virtual std::vector<std::string> getValueNames(const std::string &key) const           = 0;
     
-    virtual void markValueNamesInKeyForDeletion(const std::string &key) = 0;
+    virtual void markKeyForDeletion(const std::string &key) = 0;
 
     virtual void clearKey(const std::string &key)                                 = 0;
     virtual void clearValue(const std::string &key, const std::string &valueName) = 0;

--- a/src/plugins/administrative_templates/registry/polregistrysource.cpp
+++ b/src/plugins/administrative_templates/registry/polregistrysource.cpp
@@ -230,7 +230,7 @@ std::vector<std::string> PolRegistrySource::getNonSpecialValueNames(const std::s
     return result;
 }
 
-void PolRegistrySource::markValueNamesInKeyForDeletion(const std::string &key)
+void PolRegistrySource::markKeyForDeletion(const std::string &key)
 {
     std::vector<std::string> values = getValueNames(key);
     for (const auto &value : values)

--- a/src/plugins/administrative_templates/registry/polregistrysource.cpp
+++ b/src/plugins/administrative_templates/registry/polregistrysource.cpp
@@ -207,12 +207,44 @@ std::vector<std::string> PolRegistrySource::getValueNames(const std::string &key
     return result;
 }
 
-void PolRegistrySource::clearKey(const std::string &key)
+static bool isSpecialValueName(const std::string &str)
+{
+    // TODO: make case-insensitive
+    // TODO: check for others
+    return (str == "**deletevalues") || 
+           (str == "**delvals.")     ||
+           (str == "**deletekeys")   ||
+           (str == "**securekey")    || 
+           (str.length() >= 6 && strncmp(str.c_str(), "**del.", 6)) ||
+           (str.length() >= 7 && strncmp(str.c_str(), "**soft.", 7));
+}
+
+std::vector<std::string> PolRegistrySource::getNonSpecialValueNames(const std::string &key) const 
+{
+    std::vector<std::string> result = getValueNames(key);
+
+    result.erase(std::remove_if(result.begin(), 
+                                result.end(), 
+                                &isSpecialValueName), 
+                 result.end());
+    return result;
+}
+
+void PolRegistrySource::markValueNamesInKeyForDeletion(const std::string &key)
 {
     std::vector<std::string> values = getValueNames(key);
     for (const auto &value : values)
     {
         markValueForDeletion(key, value);
+    }
+}
+
+void PolRegistrySource::clearKey(const std::string &key)
+{
+    std::vector<std::string> values = getValueNames(key);
+    for (const auto &value : values)
+    {
+        clearValue(key, value);
     }
 }
 

--- a/src/plugins/administrative_templates/registry/polregistrysource.h
+++ b/src/plugins/administrative_templates/registry/polregistrysource.h
@@ -55,7 +55,10 @@ public:
     bool undeleteValue(const std::string &key, const std::string &valueName) override final;
     bool isValueMarkedForDeletion(const std::string &key, const std::string &valueName) const override final;
 
+    std::vector<std::string> getNonSpecialValueNames(const std::string &key) const override final;
     std::vector<std::string> getValueNames(const std::string &key) const override final;
+    void markValueNamesInKeyForDeletion(const std::string &key) override final;
+
     void clearKey(const std::string &key) override final;
     void clearValue(const std::string &key, const std::string &valueName) override final;
 

--- a/src/plugins/administrative_templates/registry/polregistrysource.h
+++ b/src/plugins/administrative_templates/registry/polregistrysource.h
@@ -57,7 +57,7 @@ public:
 
     std::vector<std::string> getNonSpecialValueNames(const std::string &key) const override final;
     std::vector<std::string> getValueNames(const std::string &key) const override final;
-    void markValueNamesInKeyForDeletion(const std::string &key) override final;
+    void markKeyForDeletion(const std::string &key) override final;
 
     void clearKey(const std::string &key) override final;
     void clearValue(const std::string &key, const std::string &valueName) override final;

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -186,10 +186,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
         {
             // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc772195(v=ws.10)
             // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
-            if (!begin.value().trimmed().isEmpty())
-            {
-                source.setValue(key, prefix + std::to_string(index), type, begin.value());
-            }
+            source.setValue(key, prefix + std::to_string(index), type, begin.value());
         }
     }
 

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -113,16 +113,11 @@ QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &source, 
     std::vector<std::string> valueNames = source.getValueNames(key);
     
     // finding and erase **delvals.
-    for (auto it = valueNames.begin(); it != valueNames.end(); ++it) {
-        if (QString::fromStdString(*it).compare("**delvals.", Qt::CaseInsensitive) == 0) {
-            it = valueNames.erase(it);
-
-            // std::vecotor<T>::erase() returning iterator that pointing 
-            // to the next element after erased
-            --it; 
-            break;
-        }
-    }
+    valueNames.erase(std::remove_if(valueNames.begin(), valueNames.end(),
+                                [](const std::string& name) {
+                                    return QString::fromStdString(name).compare("**delvals.", Qt::CaseInsensitive) == 0;
+                                }),
+                 valueNames.end());
     
     for (auto &valueName : valueNames) {
         items[valueName] = 

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -153,6 +153,13 @@ void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &ke
 
 bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QString> valueList, const std::string &key, bool explicitValue, bool expandable, std::string &prefix)
 {
+    // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc731025(v=ws.10)
+    // explicitValue cannot be used with the valuePrefix attribute.
+    if (explicitValue && !prefix.empty())
+    {
+        qWarning() << "Presentation builder::save: attempt to use explicitValue with the valuePrefix attribute";
+    }
+
     if (valueList.empty())
     {
         return true;
@@ -164,14 +171,6 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
 
     if (explicitValue)
     {
-        // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc731025(v=ws.10)
-        // explicitValue cannot be used with the valuePrefix attribute.
-        if (!prefix.empty())
-        {
-            // tmp warning msg.
-            qWarning() << "Presentation builder::save: attempt to use explicitValue with the valuePrefix attribute";
-        }
-
         for (auto begin = valueList.begin(), end = valueList.end(); begin != end; ++begin)
         {
             if (!begin.value().trimmed().isEmpty())

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -546,6 +546,14 @@ public:
                 return;
             }
 
+            // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc731025(v=ws.10)
+            // explicitValue cannot be used with the valuePrefix attribute.
+            if (listElement->valuePrefix.size() > 0 && listElement->explicitValue)
+            {
+                qWarning() << "Unable to get valid policy listElement (explicitValue cannot be used with the valuePrefix attribute).";
+                return;
+            }
+
             RegistryEntryType registryEntryType = listElement->expandable ? RegistryEntryType::REG_EXPAND_SZ
                                                                           : RegistryEntryType::REG_SZ;
 

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -178,20 +178,19 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
                 source.setValue(key, begin.key(), type, begin.value());
             }
         }
+        return true;
     }
-    else 
-    {
-        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpreg/57226664-ce00-4487-994e-a6b3820f3e49
-        // for non explicit values. Non-explicit value will be ignored.
-        source.setValue(key, "**delvals.", REG_SZ, " ");
+    
+    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpreg/57226664-ce00-4487-994e-a6b3820f3e49
+    // for non explicit values. Non-explicit value will be ignored.
+    source.setValue(key, "**delvals.", REG_SZ, " ");
 
-        size_t index = 1;
-        for (auto begin = valueList.begin(), end = valueList.end(); begin != end; ++begin, ++index)
-        {
-            // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc772195(v=ws.10)
-            // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
-            source.setValue(key, prefix + std::to_string(index), type, begin.value());
-        }
+    size_t index = 1;
+    for (auto begin = valueList.begin(), end = valueList.end(); begin != end; ++begin, ++index)
+    {
+        // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc772195(v=ws.10)
+        // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
+        source.setValue(key, prefix + std::to_string(index), type, begin.value());
     }
 
     return true;

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -153,6 +153,11 @@ void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &ke
 
 bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QString> valueList, const std::string &key, bool explicitValue, bool expandable, std::string &prefix)
 {
+    if (valueList.empty())
+    {
+        return true;
+    }
+    
     // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc770327(v=ws.10)
     // true represents expandable string type (REG_EXPAND_SZ) and false represents string type (REG_SZ)
     auto type = expandable ? REG_EXPAND_SZ : REG_SZ;

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -114,7 +114,7 @@ QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &m_source
     
     // finding and erase **delvals.
     for (auto it = valueNames.begin(); it != valueNames.end(); ++it) {
-        if (QString::fromStdString(*it).compare("**delvals.", Qt::CaseInsensitive)) {
+        if (QString::fromStdString(*it).compare("**delvals.", Qt::CaseInsensitive) == 0) {
             it = valueNames.erase(it);
 
             // std::vecotor<T>::erase() returning iterator that pointing 
@@ -156,7 +156,7 @@ void cleanUpListInRegistry(AbstractRegistrySource &m_source, const std::string &
     // clean-up all values that contain `prefix` prefix (case-insensitive)
     for (auto &value : valueNames) {
         if (value.size() > prefix.size() && 
-            QString::fromUtf8(value.c_str(), prefix.size()).compare(_prefix, Qt::CaseInsensitive))
+            QString::fromUtf8(value.c_str(), prefix.size()).compare(_prefix, Qt::CaseInsensitive) == 0)
         {
             m_source.clearValue(key, value);
         }

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -189,6 +189,10 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
     }
     else 
     {
+        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpreg/57226664-ce00-4487-994e-a6b3820f3e49
+        // for non explicit values. Non-explicit value will be ignored.
+        source.setValue(key, "**delvals.", REG_SZ, " ");
+
         size_t index = 1;
         for (auto begin = valueList.begin(), end = valueList.end(); begin != end; ++begin, ++index)
         {

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -111,14 +111,18 @@ QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &source, 
 {
     QMap<std::string, QString> items;
     std::vector<std::string> valueNames = source.getValueNames(key);
-    
-    // finding and erase **delvals.
-    valueNames.erase(std::remove_if(valueNames.begin(), valueNames.end(),
-                                [](const std::string& name) {
-                                    return QString::fromStdString(name).compare("**delvals.", Qt::CaseInsensitive) == 0;
-                                }),
-                 valueNames.end());
-    
+
+    if(!prefix.empty())
+    {
+        // remove all valueNames(from return result), that doesn't have `prefix` prefix
+        valueNames.erase(std::remove_if(valueNames.begin(), valueNames.end(),
+                         [&prefix](const std::string& str)
+                         {
+                             return !(str.length() > prefix.length() && 
+                                     strncmp(str.c_str(), prefix.c_str(), prefix.length()));
+                         }), valueNames.end());
+    }
+
     for (auto &valueName : valueNames) {
         items[valueName] = 
                 source.getValue(key, valueName).value<QString>();

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -151,7 +151,7 @@ void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &ke
     }
 }
 
-bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QString> valueList, const std::string &key, bool explicitValue, bool expandable, std::string &prefix)
+void writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QString> valueList, const std::string &key, bool explicitValue, bool expandable, std::string &prefix)
 {
     // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc731025(v=ws.10)
     // explicitValue cannot be used with the valuePrefix attribute.
@@ -162,7 +162,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
 
     if (valueList.empty())
     {
-        return true;
+        return;
     }
     
     // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc770327(v=ws.10)
@@ -178,7 +178,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
                 source.setValue(key, begin.key(), type, begin.value());
             }
         }
-        return true;
+        return;
     }
     
     // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpreg/57226664-ce00-4487-994e-a6b3820f3e49
@@ -193,7 +193,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
         source.setValue(key, prefix + std::to_string(index), type, begin.value());
     }
 
-    return true;
+    return;
 }
 
 bool *m_dataChanged  = nullptr;

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -130,29 +130,19 @@ QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &source, 
     return items;
 }
 
-void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &key)
-{
-    std::vector<std::string> valueNames = source.getValueNames(key);
-    
-    // just clean-up all values on this keypath
-    for (auto &value : valueNames) {
-        source.clearValue(key, value);
-    }
-}
-
-void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &key, const std::string &prefix)
+void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &key, const std::string &prefix = "")
 {
     // small optimization
-    if (prefix.size() == 0)
+    if (prefix.empty())
     {
-        cleanUpListInRegistry(source, key);
+        source.clearKey(key);
     }
 
     QString _prefix = QString::fromStdString(prefix);
-
-    std::vector<std::string> valueNames = source.getValueNames(key);
+    std::vector<std::string> valueNames = source.getNonSpecialValueNames(key);
     
-    // clean-up all values that contain `prefix` prefix (case-insensitive)
+    // TODO: make case-insensitive.
+    // clean-up all values that contain `prefix` prefix (case-sensitive)
     for (auto &value : valueNames) {
         if (value.size() > prefix.size() && 
             QString::fromUtf8(value.c_str(), prefix.size()).compare(_prefix, Qt::CaseInsensitive) == 0)

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -162,7 +162,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
     {
         // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc731025(v=ws.10)
         // explicitValue cannot be used with the valuePrefix attribute.
-        if (prefix.length() != 0)
+        if (!prefix.empty())
         {
             // tmp warning msg.
             qWarning() << "Presentation builder::save: attempt to use explicitValue with the valuePrefix attribute";

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -107,10 +107,10 @@ QHBoxLayout *createCaptions()
     return horizontalLayout;
 }
 
-QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &m_source, const std::string &key, const std::string &prefix)
+QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &source, const std::string &key, const std::string &prefix)
 {
     QMap<std::string, QString> items;
-    std::vector<std::string> valueNames = m_source.getValueNames(key);
+    std::vector<std::string> valueNames = source.getValueNames(key);
     
     // finding and erase **delvals.
     for (auto it = valueNames.begin(); it != valueNames.end(); ++it) {
@@ -126,39 +126,39 @@ QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &m_source
     
     for (auto &valueName : valueNames) {
         items[valueName] = 
-                m_source.getValue(key, valueName).value<QString>();
+                source.getValue(key, valueName).value<QString>();
     }
     return items;
 }
 
-void cleanUpListInRegistry(AbstractRegistrySource &m_source, const std::string &key)
+void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &key)
 {
-    std::vector<std::string> valueNames = m_source.getValueNames(key);
+    std::vector<std::string> valueNames = source.getValueNames(key);
     
     // just clean-up all values on this keypath
     for (auto &value : valueNames) {
-        m_source.clearValue(key, value);
+        source.clearValue(key, value);
     }
 }
 
-void cleanUpListInRegistry(AbstractRegistrySource &m_source, const std::string &key, const std::string &prefix)
+void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &key, const std::string &prefix)
 {
     // small optimization
     if (prefix.size() == 0)
     {
-        cleanUpListInRegistry(m_source, key);
+        cleanUpListInRegistry(source, key);
     }
 
     QString _prefix = QString::fromStdString(prefix);
 
-    std::vector<std::string> valueNames = m_source.getValueNames(key);
+    std::vector<std::string> valueNames = source.getValueNames(key);
     
     // clean-up all values that contain `prefix` prefix (case-insensitive)
     for (auto &value : valueNames) {
         if (value.size() > prefix.size() && 
             QString::fromUtf8(value.c_str(), prefix.size()).compare(_prefix, Qt::CaseInsensitive) == 0)
         {
-            m_source.clearValue(key, value);
+            source.clearValue(key, value);
         }
     }
 }

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -110,7 +110,7 @@ QHBoxLayout *createCaptions()
 QMap<std::string, QString> loadListFromRegistry(AbstractRegistrySource &source, const std::string &key, const std::string &prefix)
 {
     QMap<std::string, QString> items;
-    std::vector<std::string> valueNames = source.getValueNames(key);
+    std::vector<std::string> valueNames = source.getNonSpecialValueNames(key);
 
     if(!prefix.empty())
     {

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -138,14 +138,13 @@ void cleanUpListInRegistry(AbstractRegistrySource &source, const std::string &ke
         source.clearKey(key);
     }
 
-    QString _prefix = QString::fromStdString(prefix);
     std::vector<std::string> valueNames = source.getNonSpecialValueNames(key);
     
     // TODO: make case-insensitive.
     // clean-up all values that contain `prefix` prefix (case-sensitive)
     for (auto &value : valueNames) {
         if (value.size() > prefix.size() && 
-            QString::fromUtf8(value.c_str(), prefix.size()).compare(_prefix, Qt::CaseInsensitive) == 0)
+            strncmp(value.c_str(), prefix.c_str(), prefix.size()) == 0)
         {
             source.clearValue(key, value);
         }

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -200,7 +200,7 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
             // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
             if (!begin.value().trimmed().isEmpty())
             {
-                source.setValue(key, begin.key(), type, QString::fromStdString(prefix) + QString::number(index));
+                source.setValue(key, prefix + std::to_string(index), type, begin.value());
             }
         }
     }

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -181,7 +181,10 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
 
         for (auto begin = valueList.begin(), end = valueList.end(); begin != end; ++begin)
         {
-            source.setValue(key, begin.key(), type, begin.value());
+            if (!begin.value().trimmed().isEmpty())
+            {
+                source.setValue(key, begin.key(), type, begin.value());
+            }
         }
     }
     else 
@@ -191,7 +194,10 @@ bool writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
         {
             // https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc772195(v=ws.10)
             // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
-            source.setValue(key, begin.key(), type, QString::fromStdString(prefix) + QString::number(index));
+            if (!begin.value().trimmed().isEmpty())
+            {
+                source.setValue(key, begin.key(), type, QString::fromStdString(prefix) + QString::number(index));
+            }
         }
     }
 

--- a/src/plugins/administrative_templates/ui/presentationbuilder.cpp
+++ b/src/plugins/administrative_templates/ui/presentationbuilder.cpp
@@ -192,8 +192,6 @@ void writeListIntoRegistry(AbstractRegistrySource &source, QMap<std::string, QSt
         // valuePrefix represents the text string to be prepended to the incremented integer for registry subkey creation.
         source.setValue(key, prefix + std::to_string(index), type, begin.value());
     }
-
-    return;
 }
 
 bool *m_dataChanged  = nullptr;


### PR DESCRIPTION
gpui-0.2.44-alt1
Stands (updated to Sisyphus):
dc samba - Server 10.2-office x86-64

Customers:
Workstation 10.2 x86-64
windows 10 pro
windows 7

Steps:
- Launch the GPUI application with the Default Domain Policy.
- Go to Computer -> Administrative Templates -> Yandex -> Yandex.Browser -> URL Blocking -> Block URLs from the specified list
- Change the policy status to Enabled and set a list of URLs, for example - microsoft.ru , mail.ru
- Click OK
- Reboot clients and check the policy application

Expected result: In yandex browser, browser://policy/ contains a list of blocked urls in the URLBlocklist on all clients. Sites from the list do not open.

The actual result: In yandex browser, browser://policy/ shows an empty list of blocked urls in the URLBlocklist on windows clients -[] despite the fact that it is noted that the policy status is OK. All sites are opening. The list is correct on alt clients.

Additional: When opening the policy in RSAT and resaving, the problem goes away, the URL array "arrives" correctly.