### PR TITLE
[GPUI][BUG] Small fix for endianness 

### DIFF
--- a/src/plugins/pol/parser.cpp
+++ b/src/plugins/pol/parser.cpp
@@ -28,11 +28,11 @@ namespace pol {
 
 /*!
  * \brief Valid POL Registery file header. Binary equal valid header.
- * leToNative is used because the entry 0x5052656701000000 is 
+ * leToNative is used because the entry 0x0167655250 is 
  * equivalent to the header in case uint64_t stores a number in LittleEndian.
- * BigEndian - 0x00 0x00 0x00 0x01 0x67 0x65 0x52 0x50
+ * BigEndian - 0x00 0x00 0x00 0x01 0x67 0x65 0x52 0x50 (bytes must be swaped)
  */
-static const uint64_t valid_header = leToNative<uint64_t>(0x5052656701000000);
+static const uint64_t valid_header = leToNative<uint64_t>(0x0167655250);
 
 /*!
  * \brief Match regex `[\x20-\x7E]`

--- a/tests/auto/plugins/pol/poltest.cpp
+++ b/tests/auto/plugins/pol/poltest.cpp
@@ -53,8 +53,8 @@ void PolTest::endianness()
 void PolTest::bufferToIntegralLe()
 {
     std::stringstream buffer;
-    char tmp[4] = { 0x12, 0x34, 0x56, 0x78 };
-    const uint32_t &num = *reinterpret_cast<uint32_t *>(&tmp[0]);
+    char tmp[4] = { 0x78, 0x56, 0x34, 0x12 };
+    const uint32_t num = (pol::getEndianess() == pol::Endian::LittleEndian) ? 0x12345678 : 0x78563412;
 
     buffer.write(tmp, 4);
     buffer.seekg(0);
@@ -68,15 +68,14 @@ void PolTest::bufferToIntegralBe()
 {
     std::stringstream buffer;
     char tmp[4] = { 0x12, 0x34, 0x56, 0x78 };
-    const uint32_t &num = *reinterpret_cast<uint32_t *>(&tmp[0]);
+    const uint32_t num = (pol::getEndianess() == pol::Endian::LittleEndian) ? 0x12345678 : 0x78563412;
     uint32_t result;
 
-    buffer.write(reinterpret_cast<const char *>(&num), 4);
+    buffer.write(tmp, 4);
     buffer.seekg(0);
 
     result = pol::readIntegralFromBuffer<uint32_t, false>(buffer);
 
-    std::reverse(tmp, tmp + 4);
     QCOMPARE(result, num);
 }
 

--- a/tests/auto/plugins/pol/poltest.cpp
+++ b/tests/auto/plugins/pol/poltest.cpp
@@ -132,6 +132,21 @@ void PolTest::autogenerateCases(size_t seed)
     auto test = parser->parse(file);
     QCOMPARE(policyFile, test);
 }
+
+void PolTest::testPRegHeader()
+{
+    std::stringstream stream;
+    pol::PolicyFile file;
+    auto parser = pol::createPregParser();
+    
+    parser->write(stream, file);
+    
+    std::vector<uint8_t> result(8), expected = { 0x50, 0x52, 0x65, 0x67, 0x01, 0x00, 0x00, 0x00};
+
+    stream.read(reinterpret_cast<char*>(result.data()), 8);
+    QCOMPARE(result, expected);
+}
+
 } // namespace tests
 
 QTEST_MAIN(tests::PolTest)

--- a/tests/auto/plugins/pol/poltest.h
+++ b/tests/auto/plugins/pol/poltest.h
@@ -39,6 +39,8 @@ private slots:
 
     void testCase(QString filename);
     void autogenerateCases(size_t seed);
+
+    void testPRegHeader();
 };
 } // namespace tests
 


### PR DESCRIPTION
- Two tests have been rewritten so that they work on platform with different endianness
- A test was added for the PReg header, as the `leToNative` function was used there
- PReg header magic number has been fixed